### PR TITLE
Disable port health-check for Diego

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,4 @@ applications:
   name: rtc-slack-bot
   no-route: true
   disk_quota: 256M
+  health-check-type: none


### PR DESCRIPTION
Disable port health-check for migration to CloudFoundry Diego, which doesn't take notice of the `no-route: true` directive.